### PR TITLE
Add github action for applying checker

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/checker.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/checker.yml
@@ -1,0 +1,33 @@
+name: Checking Masterdata definitions
+on: [push]
+
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+# `contents` is for permission to the contents of the repository.
+# `pull-requests` is for permission to pull request
+permissions:
+  contents: write
+  checks: write
+  pull-requests: write
+
+env:
+  UV_SYSTEM_PYTHON: true
+
+
+jobs:
+  coveralls-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    - name: Install dependencies
+      run: |
+        uv pip install -e '.[dev]'
+    - name: Check masterdata definitions
+      run: |
+        bam_masterdata checker --file-path=./src/{{cookiecutter.module_name}} --mode=individual

--- a/{{cookiecutter.project_name}}/.github/workflows/checker.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/checker.yml
@@ -14,7 +14,7 @@ env:
 
 
 jobs:
-  coveralls-test:
+  checker:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the checking of masterdata definitions. The workflow is triggered on every push and includes several steps to set up the environment and run the checker.

New GitHub Actions workflow:

* [`{{cookiecutter.project_name}}/.github/workflows/checker.yml`](diffhunk://#diff-3a46eb398eafd19e8b6a39147788e89be0077902efdcce45f189f39612b14699R1-R33): Added a new workflow named "Checking Masterdata definitions" that runs on `push` events. It sets up permissions, environment variables, and includes steps to check out the repository, set up Python 3.12, install `uv`, install dependencies, and run the `bam_masterdata` checker.